### PR TITLE
Change notebook kernels to Python 3

### DIFF
--- a/00_test_install.ipynb
+++ b/00_test_install.ipynb
@@ -20,8 +20,8 @@
       "version": "2.7.10"
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     },
     "accelerator": "GPU"
   },

--- a/01_linear_regression.ipynb
+++ b/01_linear_regression.ipynb
@@ -21,8 +21,8 @@
       "version": "2.7.10"
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     },
     "accelerator": "GPU"
   },

--- a/02_tensorflow_logistic_regression.ipynb
+++ b/02_tensorflow_logistic_regression.ipynb
@@ -20,9 +20,9 @@
       "version": "2.7.10"
     },
     "kernelspec": {
-      "display_name": "Python 2",
+      "display_name": "Python 3",
       "language": "python",
-      "name": "python2"
+      "name": "python3"
     },
     "accelerator": "GPU"
   },

--- a/03a_tensorflow_deep_network.ipynb
+++ b/03a_tensorflow_deep_network.ipynb
@@ -20,9 +20,9 @@
       "version": "2.7.10"
     },
     "kernelspec": {
-      "display_name": "Python 2",
+      "display_name": "Python 3",
       "language": "python",
-      "name": "python2"
+      "name": "python3"
     },
     "accelerator": "GPU"
   },

--- a/03b_deep_mnist_visualize.ipynb
+++ b/03b_deep_mnist_visualize.ipynb
@@ -20,9 +20,9 @@
       "version": "2.7.10"
     },
     "kernelspec": {
-      "display_name": "Python 2",
+      "display_name": "Python 3",
       "language": "python",
-      "name": "python2"
+      "name": "python3"
     },
     "accelerator": "GPU"
   },

--- a/04_mnist_cnn.ipynb
+++ b/04_mnist_cnn.ipynb
@@ -396,9 +396,9 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/05_data_prep.ipynb
+++ b/05_data_prep.ipynb
@@ -400,9 +400,9 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/06_transfer_learning.ipynb
+++ b/06_transfer_learning.ipynb
@@ -22,9 +22,9 @@
       "version": "2.7.10"
     },
     "kernelspec": {
-      "display_name": "Python 2",
+      "display_name": "Python 3",
       "language": "python",
-      "name": "python2"
+      "name": "python3"
     },
     "accelerator": "GPU"
   },


### PR DESCRIPTION
Why? Python 2 is nearing its EOL.

Tested: opened each notebook in Colab, changed the runtime to Python 3, Runtime->Run All, confirm no errors.

One notebook is left out of this PR (transfer_learning_data.ipynb) because running it under Python 3 resulted in an error.